### PR TITLE
test new compilation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,41 @@
 [build-system]
-    requires = [
-        "setuptools",
-        "wheel"
-    ]
-    build-backend = "setuptools.build_meta"
+requires = ["setuptools", "wheel", "cython", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "plastic"
+version = "0.0.2"
+description = "Simpler and Faster Development of Tumor Phylogeny Pipelines"
+authors = [
+    { name = "Lorenzo Lucarella", email = "l.lucarella@campus.unimib.it" },
+    { name = "Simone Ciccolella", email = "simone.ciccolella@unimib.it" },
+    { name = "Andy Giacon", email = "a.giacon@campus.unimib.it" }
+]
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+dependencies = [
+    "pandas",
+    "tatsu",
+    "mp3treesim",
+    "pygraphviz",
+    "kmodes",
+    "networkx",
+    "colour",
+    "numpy",
+    "matplotlib"
+]
+
+[project.urls]
+Homepage = "https://github.com/plastic-phy/plastic"
+Repository = "https://github.com/plastic-phy/plastic"
+
+[tool.setuptools]
+packages = ["plastic", "plastic.phylogeny", "plastic.phylogeny.sasc"]
+
+[tool.setuptools.package-data]
+"plastic.phylogeny.sasc" = ["bindings/*.pxd", "bindings/*.pyx", "bindings/*.h", "sasc/*.h"]
+
+[tool.cython]
+language_level = "3"
+

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,28 @@
 import setuptools as st
+from Cython.Build import cythonize
+import numpy
 
 sascdir = 'plastic/phylogeny/sasc/'
 with open('README.md', 'r') as f:
     long_description = f.read()
+
+extensions = [
+    st.Extension(
+        "plastic.phylogeny.sasc._sasc",
+        [sascdir + "bindings/_sasc.pyx"] +  # Cython source file
+        [sascdir + filepath for filepath in [
+            "bindings/sasc-compute.c",
+            "sasc/tree.c",
+            "sasc/mt19937ar.c",
+            "sasc/vector.c",
+            "sasc/utils.c",
+            "sasc/sastep.c"
+        ]],
+        include_dirs=[sascdir + "bindings", sascdir + "sasc", numpy.get_include()],
+        extra_compile_args=["-O3", "-fopenmp", "-DNDEBUG"],
+        extra_link_args=["-O3", "-fopenmp", "-DNDEBUG"]
+    )
+]
 
 st.setup(
     name="plastic",
@@ -23,31 +43,17 @@ st.setup(
         "Topic :: Scientific/Engineering :: Bio-Informatics"
     ],
     install_requires=[
-        'pandas',
-        'tatsu',
-        'mp3treesim',
-        'pygraphviz',
-        'kmodes',
-        'networkx',
-        'colour',
-        'numpy',
-        'matplotlib'
+        "pandas",
+        "tatsu",
+        "mp3treesim",
+        "pygraphviz",
+        "kmodes",
+        "networkx",
+        "colour",
+        "numpy",
+        "matplotlib"
     ],
-    python_requires="==3.10.*",
-    ext_modules=[
-        st.Extension(
-            "plastic.phylogeny.sasc._sasc",
-            [sascdir + filepath for filepath in
-             ["bindings/_sasc.c",
-              "bindings/sasc-compute.c",
-              "sasc/tree.c",
-              "sasc/mt19937ar.c",
-              "sasc/vector.c",
-              "sasc/utils.c",
-              "sasc/sastep.c"]],
-            include_dirs=[sascdir + "bindings", sascdir + "sasc"],
-            extra_compile_args=["-O3", "-fopenmp", "-DNDEBUG"],
-            extra_link_args=["-O3", "-fopenmp", "-DNDEBUG"]
-        )
-    ]
+    python_requires=">=3.10",
+    ext_modules=cythonize(extensions, language_level="3"),
 )
+


### PR DESCRIPTION
Ho provato a fare queste modifiche per la compilazione di SASC. In sostanza quello che era fatto prima (scorrettamente) era di compilare direttamente il `bindings/_sasc.c`, mentre dovrebbe essere in creato in automatico da Cython.
Ora lo fa e riesco ad fare `pip install .` su 3.10, 3.11 e 3.12

Tuttavia non riesco ad importare il file
```
Python 3.12.9 (main, Feb  6 2025, 22:36:39) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import plastic
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ciccolella/code/plastic/plastic/plastic/__init__.py", line 4, in <module>
    from . import phylogeny
  File "/home/ciccolella/code/plastic/plastic/plastic/phylogeny/__init__.py", line 1, in <module>
    from . import SCITE, SPhyR, generic, sasc
  File "/home/ciccolella/code/plastic/plastic/plastic/phylogeny/sasc/__init__.py", line 1, in <module>
    from .sasc_run import inference
  File "/home/ciccolella/code/plastic/plastic/plastic/phylogeny/sasc/sasc_run.py", line 1, in <module>
    from ._sasc import sasc as _sasc
ModuleNotFoundError: No module named 'plastic.phylogeny.sasc._sasc'
```
Non so se queste modifiche ora creino problemi con le varie `__init__.py`, sarebbe meglio dare un'occhiata e controllare che quello che ho scritto funzioni effettivamente.